### PR TITLE
Allow Nokogiri 1.19

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,5 +2,5 @@ appraise "rails-7" do
   gem 'actionmailer',    '~> 7.0.8.4'
   gem 'activejob',       '~> 7.0.8.4'
   gem 'activesupport',   '~> 7.0.8.4'
-  gem 'nokogiri',        '~> 1.15.6'
+  gem 'nokogiri',        '~> 1.19.4'
 end

--- a/textris.gemspec
+++ b/textris.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activejob',       '< 9'
   spec.add_runtime_dependency 'activesupport',   '< 9'
   spec.add_runtime_dependency 'phony',           '~> 2.8'
-  spec.add_runtime_dependency 'nokogiri',        '~> 1.18.8'
+  spec.add_runtime_dependency 'nokogiri',        '>= 1.19.4', '< 2'
 end


### PR DESCRIPTION
## What changed

- allow Nokogiri 1.19.4 through the existing pre-2.0 compatibility boundary
- update the Rails 7 appraisal to exercise the patched Nokogiri line

## Why

Peach depends on this branch and cannot resolve Nokogiri 1.19.4 while Textris pins `~> 1.18.8`. The newer Nokogiri release fixes the open security advisories reported against Peach.

## Verification

- `RUBYOPT=-rostruct bundle _2.3.27_ exec rspec`
- 92 examples, 0 failures

The explicit `ostruct` require works around an existing Rails 8.1 test-harness assumption and is unrelated to the Nokogiri constraint.
